### PR TITLE
ci: add Jekyll build workflow

### DIFF
--- a/.github/workflows/jekyll-build.yml
+++ b/.github/workflows/jekyll-build.yml
@@ -1,0 +1,31 @@
+name: Jekyll Build
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build site
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "2.7"
+          bundler-cache: true
+
+      - name: Build with Jekyll
+        run: bundle exec jekyll build --trace
+        env:
+          JEKYLL_ENV: production


### PR DESCRIPTION
## Summary

- Add `.github/workflows/jekyll-build.yml` that runs `bundle exec jekyll build --trace` on every push to `master` and on every PR targeting `master`.
- Uses Ruby 2.7 (compatible with the locked gem set; the local dev Ruby is 2.6 but 2.7 is the lowest still supported by `setup-ruby` and works with our `Gemfile.lock`).
- Checks out LFS objects so image-bearing posts build.
- Sets `JEKYLL_ENV=production`.

Once this lands, master can be protected to require the **Build site** check before merge.

## Test plan

- [ ] CI runs on this PR and the **Build site** job passes.
- [ ] After merge, enable branch protection on `master` requiring **Build site**.