### PR TITLE
ci: deploy site to GitHub Pages with LFS assets

### DIFF
--- a/.github/workflows/jekyll-build.yml
+++ b/.github/workflows/jekyll-build.yml
@@ -1,13 +1,21 @@
-name: Jekyll Build
+name: Jekyll Build & Deploy
 
 on:
   push:
     branches: [master]
   pull_request:
     branches: [master]
+  workflow_dispatch:
 
 permissions:
   contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment, cancel in-progress runs for the same ref.
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -29,3 +37,22 @@ jobs:
         run: bundle exec jekyll build --trace
         env:
           JEKYLL_ENV: production
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    # Only deploy on pushes to master, not on pull requests.
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-22.04
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
GitHub Pages' built-in Jekyll builder checks the repo out without fetching Git LFS objects, so every file under `resources/**` was being served as a raw LFS pointer text file (e.g. images on the-big-blue post rendered as broken). Switch the workflow to a build + deploy pipeline: checkout already uses `lfs: true`, the build job uploads `_site` via `actions/upload-pages-artifact`, and a separate deploy job publishes it via `actions/deploy-pages` (push-only, skipped on PRs). Requires the repo's Pages source to be set to "GitHub Actions" in repo settings.